### PR TITLE
Add enabled checkboxes for headers

### DIFF
--- a/src/main/java/com/flop/resttester/components/keyvaluelist/KeyValueInput.java
+++ b/src/main/java/com/flop/resttester/components/keyvaluelist/KeyValueInput.java
@@ -27,15 +27,17 @@ public class KeyValueInput extends JPanel implements FocusListener {
 
     private final JTextField keyInput = new CustomTextField("Header");
     private final JTextField valueInput = new CustomTextField("Value");
+    private final JCheckBox enabledCheckbox = new JCheckBox();
     private final ActionButton deleteButton = new ActionButton("", AllIcons.Actions.Cancel);
 
     private int lastWidth = 0;
 
     public List<KeyValueInputChangeListener> listeners = new ArrayList<>();
 
-    public KeyValueInput(String key, String value) {
+    public KeyValueInput(String key, String value, boolean enabled) {
         this.keyInput.setText(key);
         this.valueInput.setText(value);
+        this.enabledCheckbox.setSelected(enabled);
 
         this.initListeners();
         this.initView();
@@ -65,14 +67,17 @@ public class KeyValueInput extends JPanel implements FocusListener {
         this.valueInput.getDocument().addDocumentListener(valueChangeListener);
         this.valueInput.addFocusListener(this);
 
+        this.enabledCheckbox.addActionListener((e) -> this.onChange(KeyValueChangeEventType.VALUE));
+
         this.deleteButton.addActionListener((e) -> this.onChange(KeyValueChangeEventType.DELETE));
     }
 
     private void initView() {
         this.keyInput.setToolTipText("Header Field");
         this.valueInput.setToolTipText("Header Value");
+        this.enabledCheckbox.setToolTipText("Enabled");
 
-        GridLayoutManager layoutManager = new GridLayoutManager(1, 3);
+        GridLayoutManager layoutManager = new GridLayoutManager(1, 4);
         layoutManager.setMargin(JBUI.insets(4, 12, 4, 8));
         this.setLayout(layoutManager);
 
@@ -84,12 +89,17 @@ public class KeyValueInput extends JPanel implements FocusListener {
                 GridConstraints.SIZEPOLICY_WANT_GROW,
                 GridConstraints.SIZEPOLICY_FIXED, null, null, null);
 
-        GridConstraints buttonConstraint = new GridConstraints(0, 2, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_HORIZONTAL,
+        GridConstraints checkboxConstraint = new GridConstraints(0, 2, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_HORIZONTAL,
+                GridConstraints.SIZEPOLICY_FIXED,
+                GridConstraints.SIZEPOLICY_FIXED, new Dimension(26, 26), new Dimension(26, 26), new Dimension(26, 26));
+
+        GridConstraints buttonConstraint = new GridConstraints(0, 3, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_HORIZONTAL,
                 GridConstraints.SIZEPOLICY_FIXED,
                 GridConstraints.SIZEPOLICY_FIXED, new Dimension(26, 26), new Dimension(26, 26), new Dimension(26, 26));
 
         this.add(this.keyInput, keyConstraint);
         this.add(this.valueInput, valueConstraint);
+        this.add(this.enabledCheckbox, checkboxConstraint);
         this.add(this.deleteButton, buttonConstraint);
     }
 
@@ -103,8 +113,9 @@ public class KeyValueInput extends JPanel implements FocusListener {
 
         this.lastWidth = preferredSize.width;
 
-        // padding 20, delete button 26, padding between 24
-        int inputWidth = (int) Math.floor((preferredSize.width - 70) / 2.0);
+        // padding 20, enabled checkbox 26, padding between 20, delete button 26, padding after 24
+        int trailingWidth = 20 + 26 + 20 + 26 + 24;
+        int inputWidth = (int) Math.floor((preferredSize.width - trailingWidth) / 2.0);
         Dimension inputSize = new Dimension(inputWidth, 28);
 
         this.keyInput.setPreferredSize(inputSize);
@@ -113,6 +124,9 @@ public class KeyValueInput extends JPanel implements FocusListener {
         this.valueInput.setPreferredSize(inputSize);
         this.valueInput.setMinimumSize(inputSize);
         this.valueInput.setMaximumSize(inputSize);
+        this.enabledCheckbox.setPreferredSize(inputSize);
+        this.enabledCheckbox.setMinimumSize(inputSize);
+        this.enabledCheckbox.setMaximumSize(inputSize);
 
         this.updateUI();
     }
@@ -145,6 +159,10 @@ public class KeyValueInput extends JPanel implements FocusListener {
 
     public String getKey() {
         return this.keyInput.getText();
+    }
+
+    public boolean getEnabled() {
+        return this.enabledCheckbox.isSelected();
     }
 
     private void notifyChange() {

--- a/src/main/java/com/flop/resttester/components/keyvaluelist/KeyValueList.java
+++ b/src/main/java/com/flop/resttester/components/keyvaluelist/KeyValueList.java
@@ -53,7 +53,7 @@ public class KeyValueList extends JPanel {
 
         this.add(scrollPane, constraint);
 
-        KeyValueInput input = new KeyValueInput("", "");
+        KeyValueInput input = new KeyValueInput("", "", true);
         input.addChangeEventListener(this::onInputChange);
         this.panel.add(input);
     }
@@ -63,7 +63,7 @@ public class KeyValueList extends JPanel {
         int width = this.getParent().getWidth();
 
         for (KeyValuePair item : items) {
-            KeyValueInput input = new KeyValueInput(item.key, item.value);
+            KeyValueInput input = new KeyValueInput(item.key, item.value, item.enabled);
             input.addChangeEventListener(this::onInputChange);
             input.setPreferredSize(new Dimension(width, this.childHeight));
             this.panel.add(input);
@@ -143,18 +143,19 @@ public class KeyValueList extends JPanel {
 
             String key = input.getKey();
             String value = input.getValue();
+            boolean enabled = input.getEnabled();
 
             if (key.isBlank()) {
                 continue;
             }
 
-            values.add(new KeyValuePair(key, value));
+            values.add(new KeyValuePair(key, value, enabled));
         }
         return values;
     }
 
     private void addEmptyInput() {
-        KeyValueInput newInput = new KeyValueInput("", "");
+        KeyValueInput newInput = new KeyValueInput("", "", true);
         newInput.addChangeEventListener(this::onInputChange);
 
         int width = this.getParent().getWidth();

--- a/src/main/java/com/flop/resttester/components/keyvaluelist/KeyValuePair.java
+++ b/src/main/java/com/flop/resttester/components/keyvaluelist/KeyValuePair.java
@@ -7,22 +7,26 @@
 
 package com.flop.resttester.components.keyvaluelist;
 
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
 public class KeyValuePair implements Cloneable {
 
     public String key;
     public String value;
+    public Boolean enabled;
 
-    public KeyValuePair(String key, String value) {
+    public KeyValuePair(String key, String value, Boolean enabled) {
         this.key = key;
         this.value = value;
+        this.enabled = enabled;
     }
 
     public JsonObject getAsJson() {
         JsonObject jObj = new JsonObject();
         jObj.addProperty("key", this.key);
         jObj.addProperty("value", this.value);
+        jObj.addProperty("enabled", this.enabled);
         return jObj;
     }
 
@@ -30,10 +34,15 @@ public class KeyValuePair implements Cloneable {
         if (!jObj.has("key") && !jObj.has("value")) {
             throw new RuntimeException("Invalid key value object. Key or value property not found.");
         }
-        return new KeyValuePair(jObj.get("key").getAsString(), jObj.get("value").getAsString());
+
+        // to maintain compatibility with older versions, set enabled to true if not present
+        JsonElement enabledJson = jObj.get("enabled");
+        boolean enabled = enabledJson == null || enabledJson.getAsBoolean();
+
+        return new KeyValuePair(jObj.get("key").getAsString(), jObj.get("value").getAsString(), enabled);
     }
 
     public KeyValuePair clone() {
-        return new KeyValuePair(this.key, this.value);
+        return new KeyValuePair(this.key, this.value, this.enabled);
     }
 }

--- a/src/main/java/com/flop/resttester/request/QueryParameterHandler.java
+++ b/src/main/java/com/flop/resttester/request/QueryParameterHandler.java
@@ -55,7 +55,7 @@ public class QueryParameterHandler {
             String value = this.model.getValueAt(i, 1).toString();
 
             if (!key.isEmpty() && !value.isEmpty()) {
-                params.add(new KeyValuePair(key, value));
+                params.add(new KeyValuePair(key, value, true));
             }
         }
         return params;

--- a/src/main/java/com/flop/resttester/request/RequestWindow.java
+++ b/src/main/java/com/flop/resttester/request/RequestWindow.java
@@ -420,7 +420,7 @@ public class RequestWindow {
         AuthenticationData authData = (AuthenticationData) this.authComboBox.getSelectedItem();
         String tag = this.nameInputField.getText();
         List<KeyValuePair> params = this.paramHandler.getParams();
-        List<KeyValuePair> headers = this.headerList.getValues();
+        List<KeyValuePair> headers = this.headerList.getValues().stream().filter(header -> header.enabled).toList();
         String body = this.jsonBodyInput.getText();
         RequestBodyType bodyType = (RequestBodyType) this.bodyTypePicker.getSelectedItem();
 


### PR DESCRIPTION
Adds checkboxes next to request headers so they can be individually enabled/disabled.

![image](https://github.com/ChargeIn/RestTester/assets/64715768/385e7796-a227-4de9-8d36-7903a233c759)
